### PR TITLE
Add support for passing in additional rspec runner arguments

### DIFF
--- a/lib/vagrant-spec/acceptance/configuration.rb
+++ b/lib/vagrant-spec/acceptance/configuration.rb
@@ -26,22 +26,20 @@ module Vagrant
         # this to whatever is on the PATH.
         attr_accessor :vagrant_path
 
-        # Array of arguments to pass to the rspec runner, overriding the
-        # default. Useful for passing in things such as alternate
-        # formatters.
-        # Default: ["--color", "--format", "Vagrant::Spec::Acceptance::Formatter"]
-        attr_accessor :rspec_args
+        # Array of arguments to append to those passed to the rspec runner,
+        # i.e. for adding additional formatters.
+        attr_accessor :rspec_args_append
 
         def initialize
           @component_paths = [
             Vagrant::Spec.source_root.join("acceptance"),
           ]
 
-          @env            = {}
-          @providers      = {}
-          @skeleton_paths = []
-          @vagrant_path   = "vagrant"
-          @rspec_args     = []
+          @env               = {}
+          @providers         = {}
+          @skeleton_paths    = []
+          @vagrant_path      = "vagrant"
+          @rspec_args_append = []
         end
 
         # Tells vagrant-spec to acceptance test a certain provider.

--- a/lib/vagrant-spec/acceptance/configuration.rb
+++ b/lib/vagrant-spec/acceptance/configuration.rb
@@ -26,6 +26,12 @@ module Vagrant
         # this to whatever is on the PATH.
         attr_accessor :vagrant_path
 
+        # Array of arguments to pass to the rspec runner, overriding the
+        # default. Useful for passing in things such as alternate
+        # formatters.
+        # Default: ["--color", "--format", "Vagrant::Spec::Acceptance::Formatter"]
+        attr_accessor :rspec_args
+
         def initialize
           @component_paths = [
             Vagrant::Spec.source_root.join("acceptance"),
@@ -35,6 +41,7 @@ module Vagrant
           @providers      = {}
           @skeleton_paths = []
           @vagrant_path   = "vagrant"
+          @rspec_args     = []
         end
 
         # Tells vagrant-spec to acceptance test a certain provider.

--- a/lib/vagrant-spec/acceptance/runner.rb
+++ b/lib/vagrant-spec/acceptance/runner.rb
@@ -17,10 +17,10 @@ module Vagrant
           @components.components
         end
 
-        def run(components)
+        def run(components, rspec_args=nil)
           components = Set.new(components || [])
 
-          args = [
+          args = rspec_args || [
             "--color",
             "--format", "Vagrant::Spec::Acceptance::Formatter",
           ]

--- a/lib/vagrant-spec/acceptance/runner.rb
+++ b/lib/vagrant-spec/acceptance/runner.rb
@@ -17,13 +17,13 @@ module Vagrant
           @components.components
         end
 
-        def run(components, rspec_args=nil)
+        def run(components, rspec_args_append=[])
           components = Set.new(components || [])
 
-          args = rspec_args || [
+          args = [
             "--color",
             "--format", "Vagrant::Spec::Acceptance::Formatter",
-          ]
+          ] + rspec_args_append
 
           with_world do
             # Filter out the components

--- a/lib/vagrant-spec/cli.rb
+++ b/lib/vagrant-spec/cli.rb
@@ -31,7 +31,7 @@ module Vagrant
         end
 
         Acceptance::Runner.new(paths: Acceptance.config.component_paths).
-          run(options[:components])
+          run(options[:components], Acceptance.config.rspec_args)
       end
     end
   end

--- a/lib/vagrant-spec/cli.rb
+++ b/lib/vagrant-spec/cli.rb
@@ -31,7 +31,7 @@ module Vagrant
         end
 
         Acceptance::Runner.new(paths: Acceptance.config.component_paths).
-          run(options[:components], Acceptance.config.rspec_args)
+          run(options[:components], Acceptance.config.rspec_args_append)
       end
     end
   end

--- a/spec/acceptance/configuration_spec.rb
+++ b/spec/acceptance/configuration_spec.rb
@@ -6,6 +6,10 @@ describe Vagrant::Spec::Acceptance::Configuration do
       expect(subject.providers).to be_empty
     end
 
+    it "has no rspec_args_append initially" do
+      expect(subject.rspec_args_append).to be_empty
+    end
+
     it "can add providers" do
       subject.provider "foo", option: :bar
 


### PR DESCRIPTION
This enables passing additional arguments to the RSpec runner, i.e. for additional formatters.

Example ``vagrant-spec.config.rb``:

```
require 'pathname'
require "vagrant-spec/acceptance"
require 'rspec_junit_formatter'

Vagrant::Spec::Acceptance.configure do |c|
  acceptance_dir = Pathname.new File.expand_path("../spec/acceptance", __FILE__)
  c.component_paths = [acceptance_dir.to_s]
  c.skeleton_paths = [(acceptance_dir + 'skeletons').to_s]
  c.rspec_args_append = [
    '--format',
    'RspecJunitFormatter',
    '--out',
    'results.xml',
  ]

  c.provider ENV['VS_PROVIDER'], box: ENV['VS_BOX_PATH'], skeleton_path: c.skeleton_paths
end
```

This generates a JUnit XML results file at ``results.xml``.

I may have just missed them, but I couldn't find any specs for CLI or Runner.