### PR TITLE
AcceptanceIsolatedEnvironment - add attr_accessor for :env to allow setting custom env vars

### DIFF
--- a/lib/vagrant-spec/acceptance/isolated_environment.rb
+++ b/lib/vagrant-spec/acceptance/isolated_environment.rb
@@ -13,6 +13,8 @@ module Vagrant
     # This class extends the normal IsolatedEnvironment to add some
     # additional helpers for executing applications within that environment.
     class AcceptanceIsolatedEnvironment < IsolatedEnvironment
+      attr_accessor :env
+      
       def initialize(apps: nil, env: nil, skeleton_paths: nil)
         super()
 


### PR DESCRIPTION
As I mentioned in #15, I was having serious issues with specs that actually run ``vagrant add`` and ``vagrant up`` and spin up a VirtualBox VM. It seems that VirtualBox was storing state between spec runs, which caused failures (VBox was dying with errors trying to read a ``VirtualBox.xml-tmp`` under a tmpdir from a **previous** spec).

This just adds an attr_accessor for ``env`` in AcceptanceIsolatedEnvironment, which allows setting environment variables after creation. These could be things like API credentials, or in my case (to solve the VirtualBox issue), ``environment.env['VBOX_USER_HOME'] = environment.homedir.to_s``.