### PR TITLE
Fix "synced_folders" skeleton

### DIFF
--- a/acceptance/support-skeletons/synced_folders/Vagrantfile
+++ b/acceptance/support-skeletons/synced_folders/Vagrantfile
@@ -2,5 +2,5 @@ Vagrant.configure("2") do |config|
   config.vm.box = "basic"
 
   # Test that disabled works
-  config.vm.synced_folder ".", "/foo", disabled: true
+  config.vm.synced_folder "../", "/foo", disabled: true
 end


### PR DESCRIPTION
"." should not be disabled, because this is a default synced folder in Vagrant.
To test synced folder is disabled we should specify some other path in skeleton, for example "../"

Otherwise, this test is always failed because "." is disabled and "/vagrant" mount point does not exist:
https://github.com/mitchellh/vagrant-spec/blob/f298379bedb844f8db6d3fbf57cfced542e746f0/acceptance/provider/synced_folder_spec.rb#L25