### PR TITLE
Increase timeout for "assert_network" method

### DIFF
--- a/lib/vagrant-spec/acceptance/rspec/context.rb
+++ b/lib/vagrant-spec/acceptance/rspec/context.rb
@@ -74,7 +74,7 @@ shared_context "acceptance" do
       result = Net::HTTP.get_response(URI.parse(url))
       expect(result.code).to eql("200")
     rescue
-      if tries < 5
+      if tries < 10
         tries += 1
         sleep 2
         retry


### PR DESCRIPTION
On some slow hosts it could take a long time to run "vagrant ssh", which is used here to run an HTTP server.
I've run into this issue while testing `parallels` provider. I've noticed that 10 seconds could be not enough to run HTTP server and get a response, so it cause a test failure.
20 seconds (10 tries) are more tolerant for slow hosts and should be applicable for most of cases.

cc:\ @mitchellh @sethvargo