### PR TITLE
Add "assert_retries" configuration option

### DIFF
--- a/lib/vagrant-spec/acceptance/configuration.rb
+++ b/lib/vagrant-spec/acceptance/configuration.rb
@@ -11,6 +11,11 @@ module Vagrant
         # paths.
         attr_accessor :component_paths
 
+        # Number of times which assertion should be repeated before raising
+        # an exception when it occurs. By default it is 5. It is recommended
+        # to increate this value if you run tests on the slow host machine.
+        attr_accessor :assert_retries
+
         # Additional environmental variables to set for environments.
         attr_reader :env
 
@@ -31,6 +36,7 @@ module Vagrant
             Vagrant::Spec.source_root.join("acceptance"),
           ]
 
+          @assert_retries = 5
           @env            = {}
           @providers      = {}
           @skeleton_paths = []

--- a/lib/vagrant-spec/acceptance/rspec/context.rb
+++ b/lib/vagrant-spec/acceptance/rspec/context.rb
@@ -74,7 +74,7 @@ shared_context "acceptance" do
       result = Net::HTTP.get_response(URI.parse(url))
       expect(result.code).to eql("200")
     rescue
-      if tries < 5
+      if tries < config.assert_retries
         tries += 1
         sleep 2
         retry


### PR DESCRIPTION
On some slow hosts it could take a long time to run "vagrant ssh", which is used here to run an HTTP server.
This configuration option allows to override the number of times which assertion should be repeated
before raising an exception when it occurs.

@sethvargo Do you have any suggestions about the option name / description?