### PR TITLE
Support installation as Vagrant plugin

### DIFF
--- a/lib/vagrant-spec.rb
+++ b/lib/vagrant-spec.rb
@@ -18,3 +18,8 @@ module Vagrant
     end
   end
 end
+
+# Only load plugin interface if running within Vagrant context
+if defined?(VagrantPlugins)
+  require "vagrant-spec/vagrant-plugin/plugin"
+end

--- a/lib/vagrant-spec/vagrant-plugin/command.rb
+++ b/lib/vagrant-spec/vagrant-plugin/command.rb
@@ -1,0 +1,41 @@
+require "optparse"
+
+module VagrantPlugins
+  module VagrantSpec
+    class Command < Vagrant.plugin(2, :command)
+      def self.synopsis
+        "run vagrant-spec on installed version of Vagrant"
+      end
+
+      def execute
+        options = {}
+        opts = OptionParser.new do |o|
+          o.banner = "Usage: vagrant vagrant-spec <config file path>"
+        end
+
+        argv = parse_options(opts)
+        return if !argv
+        if argv.empty? || argv.length > 1
+          raise Vagrant::Errors::CLIInvalidUsage,
+            help: opts.help.chomp
+        end
+
+        require "vagrant-spec/cli"
+        require Vagrant.source_root.join("test/acceptance/base").to_s
+
+        Vagrant::Spec::Acceptance.configure do |c|
+          c.component_paths << Vagrant.source_root.join("test/acceptance").to_s
+          c.skeleton_paths << Vagrant.source_root.join("test/acceptance/skeletons").to_s
+        end
+
+        config_path = argv.first
+        if !File.file?(config_path)
+          raise ArgumentError.new "Invalid configuration file path provided"
+        end
+
+        cli = Vagrant::Spec::CLI.new([], config: config_path)
+        cli.test
+      end
+    end
+  end
+end

--- a/lib/vagrant-spec/vagrant-plugin/plugin.rb
+++ b/lib/vagrant-spec/vagrant-plugin/plugin.rb
@@ -1,0 +1,17 @@
+require "vagrant"
+
+module VagrantPlugins
+  module VagrantSpec
+    class Plugin < Vagrant.plugin(2)
+      name "vagrant-spec"
+      description <<-DESC
+      Run vagrant-spec on installed version of Vagrant
+      DESC
+
+      command("vagrant-spec") do
+        require_relative "command"
+        Command
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows vagrant-spec to be installed as a Vagrant plugin and run as
a subcommand. Provides support for testing the Vagrant version the plugin
is installed within.