### PR TITLE
Add run mode configuration option and expand plugin command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-    - 2.0.0
+    - 2.2.5
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/acceptance/cli/init_spec.rb
+++ b/acceptance/cli/init_spec.rb
@@ -3,10 +3,10 @@ describe "vagrant CLI: init", component: "cli/init" do
 
   it "creates a Vagrantfile in the working directory" do
     vagrantfile = environment.workdir.join("Vagrantfile")
-    expect(vagrantfile.exist?).to_not be_true
+    expect(vagrantfile.exist?).to_not be(true)
 
     assert_execute("vagrant", "init")
-    expect(vagrantfile.exist?).to be_true
+    expect(vagrantfile.exist?).to be(true)
   end
 
   it "creates a Vagrantfile with the box set to the given argument" do
@@ -30,7 +30,7 @@ describe "vagrant CLI: init", component: "cli/init" do
     vagrantfile = environment.workdir.join("foo")
 
     assert_execute("vagrant", "init", "--output", "foo")
-    expect(vagrantfile.exist?).to be_true
+    expect(vagrantfile.exist?).to be(true)
     expect(vagrantfile.read).to match(/^Vagrant\.configure/)
   end
 

--- a/acceptance/output/plugin_output.rb
+++ b/acceptance/output/plugin_output.rb
@@ -2,9 +2,26 @@ require "vagrant-spec/acceptance/output"
 
 module Vagrant
   module Spec
+    # Default plugins within plugin list when run mode
+    # is set as "plugin"
+    DEFAULT_PLUGINS = ["vagrant-share".freeze].freeze
+
     # Tests the Vagrant plugin list output has no plugins
     OutputTester[:plugin_list_none] = lambda do |text|
-      text =~ /^No plugins/
+      if Vagrant::Spec::Acceptance.config.run_mode == "plugin"
+        valid = DEFAULT_PLUGINS.all? do |plugin_name|
+          text.include?(plugin_name)
+        end
+        if valid
+          valid = !text.lines.any? do |line|
+            !line.start_with?(" ") &&
+              !DEFAULT_PLUGINS.include?(line.split(/\s/).first)
+          end
+        end
+        valid
+      else
+        text =~ /^No plugins/
+      end
     end
 
     # Tests that plugin list shows a plugin
@@ -14,7 +31,7 @@ module Vagrant
 
     # Tests that Vagrant plugin install fails to a plugin not found
     OutputTester[:plugin_install_not_found] = lambda do |text, name|
-      text =~ /^The plugin '#{name}' could not be/
+      text =~ /^Unable to resolve dependency .* '#{name}/
     end
 
     # Tests that Vagrant plugin install fails to a plugin not found

--- a/lib/vagrant-spec/acceptance/configuration.rb
+++ b/lib/vagrant-spec/acceptance/configuration.rb
@@ -31,6 +31,12 @@ module Vagrant
         # this to whatever is on the PATH.
         attr_accessor :vagrant_path
 
+        # The run mode of vagrant spec. By default this is "standalone" but
+        # can be set to "plugin" when being run from the builtin plugin
+        # command. Useful to tailor acceptance tests where behavior is
+        # different depending on mode.
+        attr_accessor :run_mode
+
         def initialize
           @component_paths = [
             Vagrant::Spec.source_root.join("acceptance"),
@@ -41,6 +47,7 @@ module Vagrant
           @providers      = {}
           @skeleton_paths = []
           @vagrant_path   = "vagrant"
+          @run_mode       = "standalone"
         end
 
         # Tells vagrant-spec to acceptance test a certain provider.

--- a/lib/vagrant-spec/vagrant-plugin/command.rb
+++ b/lib/vagrant-spec/vagrant-plugin/command.rb
@@ -10,7 +10,19 @@ module VagrantPlugins
       def execute
         options = {}
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant vagrant-spec <config file path>"
+          o.banner = "Usage: vagrant vagrant-spec [options] <config file path>"
+          o.separator ""
+          o.separator "Options:"
+          o.separator ""
+
+          o.on("-c", "--component", "Specific component to test") do |c|
+            options[:components] ||= []
+            options[:components] << c
+          end
+
+          o.on("-e", "--example", "Specific example to test") do |e|
+            options[:example] = e
+          end
         end
 
         argv = parse_options(opts)
@@ -24,6 +36,7 @@ module VagrantPlugins
         require Vagrant.source_root.join("test/acceptance/base").to_s
 
         Vagrant::Spec::Acceptance.configure do |c|
+          c.run_mode = "plugin"
           c.component_paths << Vagrant.source_root.join("test/acceptance").to_s
           c.skeleton_paths << Vagrant.source_root.join("test/acceptance/skeletons").to_s
         end
@@ -33,7 +46,7 @@ module VagrantPlugins
           raise ArgumentError.new "Invalid configuration file path provided"
         end
 
-        cli = Vagrant::Spec::CLI.new([], config: config_path)
+        cli = Vagrant::Spec::CLI.new([], options.merge(config: config_path))
         cli.test
       end
     end


### PR DESCRIPTION
Adds a run mode configuration option to allow tests to tailor expectations depending on mode. Supports components and example options via plugin command. 