### PR TITLE
Run control options

### DIFF
--- a/acceptance/cli/plugin_spec.rb
+++ b/acceptance/cli/plugin_spec.rb
@@ -148,7 +148,7 @@ describe "vagrant CLI: plugin", component: "cli/plugin" do
       result = execute("vagrant", "plugin", "license", name, tempfile.path)
       expect(result).to exit_with(0)
 
-      f = environment.homedir.join(".vagrant.d", "license-#{name}.lic")
+      f = environment.homedir.join("license-#{name}.lic")
       expect(f).to be_file
       expect(f.read).to eql("HELLO\n")
     end

--- a/acceptance/output/plugin_output.rb
+++ b/acceptance/output/plugin_output.rb
@@ -31,7 +31,7 @@ module Vagrant
 
     # Tests that Vagrant plugin install fails to a plugin not found
     OutputTester[:plugin_install_not_found] = lambda do |text, name|
-      text =~ /^Unable to resolve dependency .* '#{name}/
+      text =~ /Unable to resolve dependency:.* '#{name}/
     end
 
     # Tests that Vagrant plugin install fails to a plugin not found

--- a/lib/vagrant-spec/acceptance/runner.rb
+++ b/lib/vagrant-spec/acceptance/runner.rb
@@ -32,7 +32,7 @@ module Vagrant
               bad = []
               @world.example_groups.each do |g|
                 next if !g.metadata.has_key?(:component)
-                bad << g if !components.include?(g.metadata[:component])
+                bad << g if components.none?{|pattern| File.fnmatch?(pattern, g.metadata[:component])}
               end
 
               bad.each do |b|

--- a/lib/vagrant-spec/cli.rb
+++ b/lib/vagrant-spec/cli.rb
@@ -21,6 +21,7 @@ module Vagrant
       end
 
       option :components, type: :array, desc: "components to test. defaults to all"
+      option :without_components, type: :array, desc: "components to not test"
       option :config, type: :string, default: "vagrant-spec.config.rb", desc: "path to config file to load"
       option :example, type: :string, default: nil, desc: "specific example to run"
       desc "test", "runs the specs"
@@ -28,7 +29,7 @@ module Vagrant
         load_config
 
         Acceptance::Runner.new(paths: Acceptance.config.component_paths).
-          run(options[:components], example: options[:example])
+          run(options[:components], example: options[:example], without_components: options[:without_components])
       end
 
       protected

--- a/lib/vagrant-spec/vagrant-plugin/command.rb
+++ b/lib/vagrant-spec/vagrant-plugin/command.rb
@@ -24,6 +24,11 @@ module VagrantPlugins
             options[:components] << c
           end
 
+          o.on("-w", "--without-component COMPONENT", "Specific component to not test") do |c|
+            options[:without_components] ||= []
+            options[:without_components] << c
+          end
+
           o.on("-e", "--example EXAMPLE", "Specific example to test") do |e|
             options[:example] = e
           end


### PR DESCRIPTION
Adds more control for running vagrant-spec. Support glob matching on components option. Add option for components to skip. Make builtin acceptance tests pass. Enable or disable packaged tests via flag with plugin command.